### PR TITLE
Fix unintended glob match on case-insensitive systems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,9 @@ def clean():
     """Remove unneeded files."""
     tokens = glob(os.path.join("pya2l", "*tokens"))
     interp = glob(os.path.join("pya2l", "*interp"))
-    listener = glob(os.path.join("pya2l", "*Listener.py"))
+    listener = [
+        glob(os.path.join("pya2l", i + "Listener.py"))[0] for i in ["a2l", "aml"]
+    ]
 
     for unneeded in tokens + interp + listener:
         os.remove(unneeded)


### PR DESCRIPTION
`glob(os.path.join("pya2l", "*Listener.py"))` matches pya2l/a2l_listener.py on case-insensitive systems (e.g. Windows). My bad.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
