### PR TITLE
Import a2l-file from any directory

### DIFF
--- a/pya2l/__init__.py
+++ b/pya2l/__init__.py
@@ -130,8 +130,9 @@ class DB(object):
         """
         self._pth, self._base = path.split(file_name)
         fbase, ext = path.splitext(self._base)
-        self._dbfn = "{}.a2ldb".format(fbase)
+        self._dbfn = path.join(self._pth, "{}.a2ldb".format(fbase))
         if not ext or ext.lower() == ".a2l" or ext.lower() == ".a2ldb":
             self._a2lfn = "{}.a2l".format(fbase)
         else:
             self._a2lfn = "{}{}".format(fbase, ext)
+        self._a2lfn = path.join(self._pth, self._a2lfn)


### PR DESCRIPTION
Currently, a2l-files can only be imported from the working directory. After this change they can be imported from any directory. The a2ldb-file will be generated in the same directory as the a2l-file, i.e. same as the current behavior.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] My code follows the code style of this project.
- [x] All new and existing tests passed.
