### PR TITLE
attempt to fix linux build

### DIFF
--- a/pya2l/aml/aml_lexer.hpp
+++ b/pya2l/aml/aml_lexer.hpp
@@ -17,7 +17,7 @@
 
 static const std::regex AML_REGEX{ R"""(((/\*.*?\*/)|(//.*?$))|(\"[^\"]*?\")|(/begin|/end|block|enum|taggedstruct|taggedunion|struct)|([;,=\*\{\}\[\]\(\)])|(char|long|uchar|ulong|int64|uint64|int|uint|double|float|float16)|(\b[a-zA-Z_][a-zA-Z_0-9.]*\b)|(\b([+\-]?(\d+([.]\d*)?([eE][+\-]?\d+)?|[.]\d+([eE][+\-]?\d+)?))\b)|(\b((0[xX][0-9a-fA-F]+)|([+\-]?[0-9]+))\b))""", std::regex_constants::ECMAScript };    // std::regex_constants::ECMAScript, std::regex::extended
 
-enum class AmlTokenType : std::uint8_t {
+enum class AmlTokenType : uint8_t {
     NONE = 0,
     IDENT = 1,
     FLOAT = 2,
@@ -44,7 +44,7 @@ enum class AmlTokenType : std::uint8_t {
     BLOCK = 24,
 };
 
-using TokenDataType = std::optional<std::variant<std::int64_t, long double, std::string, AMLPredefinedTypeEnum>>;
+using TokenDataType = std::optional<std::variant<int64_t, long double, std::string, AMLPredefinedTypeEnum>>;
 
 struct AmlToken {
     AmlTokenType type{ AmlTokenType::NONE };

--- a/pya2l/aml/aml_parser.hpp
+++ b/pya2l/aml/aml_parser.hpp
@@ -68,12 +68,12 @@ class AMLParser {
         return variant_get<std::string>(*match_get_value(AmlTokenType::IDENT));
     }
 
-    auto get_int() -> std::int64_t {
+    auto get_int() -> int64_t {
         auto token = current_token();
         auto value = *token.value;
         consume();
-        if (std::holds_alternative<std::int64_t >(value)) {
-            return std::get<std::int64_t>(value);
+        if (std::holds_alternative<int64_t >(value)) {
+            return std::get<int64_t>(value);
         } else if (std::holds_alternative<long double>(value)) {
             return static_cast<long double>(std::get<long double>(value));
         } else if (std::holds_alternative<std::string>(value)) {
@@ -413,9 +413,9 @@ class AMLParser {
         }
     }
 
-    auto array_specifier() -> std::vector<std::int64_t> {
-        std::vector<std::int64_t> result;
-        std::int64_t              value;
+    auto array_specifier() -> std::vector<int64_t> {
+        std::vector<int64_t> result;
+        int64_t              value;
         auto                      token = current_token();
         if (token.type == AmlTokenType::LSQ) {
             while (true) {

--- a/pya2l/aml/aml_visitor.cpp
+++ b/pya2l/aml/aml_visitor.cpp
@@ -275,7 +275,7 @@ std::any AmlVisitor::visitMember(amlParser::MemberContext *ctx) {
     const auto            ctx_a = ctx->a;
     const auto            ctx_b = ctx->b;
     std::vector<uint64_t> arrary_specifier{};
-    std::int64_t          value{ 0 };
+    int64_t          value{ 0 };
     Type                 *tp = nullptr;
     std::optional<BlockDefinition> block{std::nullopt};
 
@@ -294,11 +294,11 @@ std::any AmlVisitor::visitMember(amlParser::MemberContext *ctx) {
         for (const auto& elem : ctx_a) {
             const auto value_cont = std::any_cast<numeric_t>(visit(elem));
 
-            if (std::holds_alternative<std::int64_t>(value_cont)) {
-                value = std::get<std::int64_t>(value_cont);
+            if (std::holds_alternative<int64_t>(value_cont)) {
+                value = std::get<int64_t>(value_cont);
             }
             else if (std::holds_alternative<long double>(value_cont)) {
-                value = static_cast<std::int64_t>(std::get<long double>(value_cont));
+                value = static_cast<int64_t>(std::get<long double>(value_cont));
             }
             arrary_specifier.push_back(value);
         }

--- a/pya2l/aml/ifdata_lexer.hpp
+++ b/pya2l/aml/ifdata_lexer.hpp
@@ -11,7 +11,7 @@
 
 static const std::regex AML_REGEX{ R"""(((/\*.*?\*/)|(//.*?$))|(\"[^\"]*?\")|(/begin|/end)|(\b[a-zA-Z_][a-zA-Z_0-9.]*\b)|(\b([+\-]?(\d+([.]\d*)?([eE][+\-]?\d+)?|[.]\d+([eE][+\-]?\d+)?))\b)|(\b((0[xX][0-9a-fA-F]+)|([+\-]?[0-9]+))\b))""", std::regex_constants::ECMAScript | std::regex_constants::icase };
 
-enum class TokenType : std::uint8_t {
+enum class TokenType : uint8_t {
     NONE = 0,  
     IDENT = 1,
     FLOAT = 2,
@@ -22,7 +22,7 @@ enum class TokenType : std::uint8_t {
     END = 8,
 };
 
-using TokenDataType = std::optional<std::variant<std::int64_t, long double, std::string>>;
+using TokenDataType = std::optional<std::variant<int64_t, long double, std::string>>;
 
 struct Token {
     TokenType type{TokenType::NONE};

--- a/pya2l/aml/klasses.hpp
+++ b/pya2l/aml/klasses.hpp
@@ -64,8 +64,8 @@ inline std::string get_string(auto var) {
 }
 
 inline long double as_double(const numeric_t& value) {
-    if (std::holds_alternative<std::int64_t>(value)) {
-        return static_cast<long double>(std::get<std::int64_t>(value));
+    if (std::holds_alternative<int64_t>(value)) {
+        return static_cast<long double>(std::get<int64_t>(value));
     } else if (std::holds_alternative<long double>(value)) {
         return std::get<long double>(value);
     }
@@ -135,18 +135,18 @@ class Enumeration {
    public:
 
     explicit Enumeration(const std::string& name, const std::vector<Enumerator>& enumerators) : m_name(name) {
-        std::uint64_t last_idx = 0ULL;
-        std::int64_t  value    = 0ULL;
+        uint64_t last_idx = 0ULL;
+        int64_t  value    = 0ULL;
         for (const auto& en : enumerators) {
             auto tag       = en.get_tag();
             auto value_opt = en.get_value();
             if (value_opt) {
                 auto value_cont = *value_opt;
 
-                if (std::holds_alternative<std::int64_t>(value_cont)) {
-                    value = std::get<std::int64_t>(value_cont);
+                if (std::holds_alternative<int64_t>(value_cont)) {
+                    value = std::get<int64_t>(value_cont);
                 } else if (std::holds_alternative<long double>(value_cont)) {
-                    value = static_cast<std::int64_t>(std::get<long double>(value_cont));
+                    value = static_cast<int64_t>(std::get<long double>(value_cont));
                 }
                 m_enumerators[tag] = value;
                 last_idx           = value + 1ULL;
@@ -160,14 +160,14 @@ class Enumeration {
         return m_name;
     }
 
-    const std::map<std::string, std::uint64_t>& get_enumerators() const noexcept {
+    const std::map<std::string, uint64_t>& get_enumerators() const noexcept {
         return m_enumerators;
     }
 
    private:
 
     std::string                          m_name;
-    std::map<std::string, std::uint64_t> m_enumerators{};
+    std::map<std::string, uint64_t> m_enumerators{};
 };
 
 using EnumerationOrReferrer = std::variant<std::monostate, Referrer, Enumeration>;
@@ -209,7 +209,7 @@ public:
 
     AMLPredefinedType() = delete;
 
-    AMLPredefinedType(AMLPredefinedTypeEnum pdt, const std::vector<std::int64_t>& arr_spec) :
+    AMLPredefinedType(AMLPredefinedTypeEnum pdt, const std::vector<int64_t>& arr_spec) :
         m_pdt(pdt), m_arr_spec(arr_spec) {
     }
 
@@ -217,14 +217,14 @@ public:
         return m_pdt;
     }
 
-    const std::vector<std::int64_t>& get_array_spec() const noexcept {
+    const std::vector<int64_t>& get_array_spec() const noexcept {
         return m_arr_spec;
     }
 
 private:
 
     AMLPredefinedTypeEnum m_pdt;
-    std::vector<std::int64_t> m_arr_spec{};
+    std::vector<int64_t> m_arr_spec{};
 };
 
 

--- a/pya2l/aml/marshal.cpp
+++ b/pya2l/aml/marshal.cpp
@@ -20,20 +20,20 @@ void dumps(std::stringstream& ss, std::shared_ptr<Type> tp_);
 // AMLPredefinedType
 inline void dumps(std::stringstream& ss, const AMLPredefinedType& pdt) {
     ss << to_binary<std::string>("PD");
-    auto value = static_cast<std::uint8_t>(pdt.get_pdt());
+    auto value = static_cast<uint8_t>(pdt.get_pdt());
     ss << to_binary(value);
 	const auto& arr_spec = pdt.get_array_spec();
 	const std::size_t array_size = std::size(arr_spec);
 	ss << to_binary(array_size);
-	for (std::uint32_t arr : arr_spec) {
-		ss << to_binary<std::uint32_t>(arr);
+	for (uint32_t arr : arr_spec) {
+		ss << to_binary<uint32_t>(arr);
 	}
 }
 
 // Referrer.
 inline void dumps(std::stringstream& ss, const Referrer& ref) {
     ss << to_binary<std::string>("R");
-    auto cat = static_cast<std::uint8_t>(ref.get_category());
+    auto cat = static_cast<uint8_t>(ref.get_category());
     auto idf = ref.get_identifier();
     ss << to_binary(cat);
     ss << to_binary(idf);
@@ -208,7 +208,7 @@ inline void dumps(std::stringstream& ss, const EnumerationOrReferrer& er) {
         ss << to_binary(enumerator_count);
         for (const auto& [tag, value] : enumerators) {
             ss << to_binary(tag);
-            ss << to_binary<std::uint32_t>(value);
+            ss << to_binary<uint32_t>(value);
         }
     } else if (std::holds_alternative<Referrer>(er)) {
         auto ref = std::get<Referrer>(er);

--- a/pya2l/aml/types.hpp
+++ b/pya2l/aml/types.hpp
@@ -9,9 +9,9 @@
 	
 
 using string_opt_t = std::optional<std::string>;
-using numeric_t    = std::variant<std::monostate, std::int64_t, long double>;
+using numeric_t    = std::variant<std::monostate, int64_t, long double>;
 
-enum class AMLPredefinedTypeEnum : std::uint8_t {
+enum class AMLPredefinedTypeEnum : uint8_t {
     CHAR   = 0,
     INT    = 1,
     LONG   = 2,
@@ -25,14 +25,14 @@ enum class AMLPredefinedTypeEnum : std::uint8_t {
     FLOAT16 = 10,
 };
 
-enum class ReferrerType : std::uint8_t {
+enum class ReferrerType : uint8_t {
     Enumeration      = 0,
     StructType       = 1,
     TaggedStructType = 2,
     TaggedUnionType  = 3,
 };
 
-enum class TypeType : std::uint8_t {
+enum class TypeType : uint8_t {
     PredefinedType   = 0,
     Enumeration      = 1,
     StructType       = 2,

--- a/pya2l/aml/unmarshal.hpp
+++ b/pya2l/aml/unmarshal.hpp
@@ -46,14 +46,14 @@ class Reader {
 class Node {
    public:
 
-    enum class NodeType : std::uint8_t {
+    enum class NodeType : uint8_t {
         TERMINAL,
         MAP,
         AGGR,
         NONE,
     };
 
-    enum class AmlType : std::uint8_t {
+    enum class AmlType : uint8_t {
         NONE,
         TYPE,
         TERMINAL,
@@ -309,7 +309,7 @@ class Node {
     map_t      m_map{};
 };
 
-inline Node make_pdt(AMLPredefinedTypeEnum type, const std::vector<std::uint32_t>& array_spec) {
+inline Node make_pdt(AMLPredefinedTypeEnum type, const std::vector<uint32_t>& array_spec) {
     Node::list_t lst{};
 
     for (const auto& arrs : array_spec) {
@@ -331,9 +331,9 @@ inline Node make_referrer(ReferrerType category, const std::string& identifier) 
     return Node(Node::AmlType::REFERRER, map);
 }
 
-using enumerators_t = std::map<std::string, std::uint32_t>;
+using enumerators_t = std::map<std::string, uint32_t>;
 
-inline Node make_enumerator(const std::string& name, std::uint32_t value) {
+inline Node make_enumerator(const std::string& name, uint32_t value) {
     Node::map_t map = {
         { "NAME",  Node(Node::AmlType::TERMINAL, name)  },
         { "VALUE", Node(Node::AmlType::TERMINAL, value) }
@@ -457,17 +457,17 @@ class Unmarshaller {
     }
 
     Node load_pdt() {
-        auto tp = static_cast<AMLPredefinedTypeEnum>(m_reader.from_binary<std::uint8_t>());
+        auto tp = static_cast<AMLPredefinedTypeEnum>(m_reader.from_binary<uint8_t>());
         auto                       arr_count = m_reader.from_binary<std::size_t>();
-        std::vector<std::uint32_t> array_spec;
+        std::vector<uint32_t> array_spec;
         for (auto idx = 0UL; idx < arr_count; ++idx) {
-            array_spec.push_back(m_reader.from_binary<std::uint32_t>());
+            array_spec.push_back(m_reader.from_binary<uint32_t>());
         }
         return make_pdt(tp, array_spec);
     }
 
     Node load_referrrer() {
-        const auto  cat        = ReferrerType(m_reader.from_binary<std::uint8_t>());
+        const auto  cat        = ReferrerType(m_reader.from_binary<uint8_t>());
         const auto& identifier = m_reader.from_binary_str();
         return make_referrer(cat, identifier);
     }
@@ -481,7 +481,7 @@ class Unmarshaller {
 
             for (auto idx = 0UL; idx < enumerator_count; ++idx) {
                 auto tag   = m_reader.from_binary_str();
-                auto value = m_reader.from_binary< std::uint32_t>();
+                auto value = m_reader.from_binary< uint32_t>();
                 enumerators.emplace(tag, value);
             }
             return make_enumeration(name, enumerators);

--- a/pya2l/extensions/a2ltoken.hpp
+++ b/pya2l/extensions/a2ltoken.hpp
@@ -10,7 +10,7 @@
     #include <map>
     #include <string>
 
-enum class A2LTokenType : std::uint16_t {
+enum class A2LTokenType : uint16_t {
     INVALID                      = 0,
     ALIGNMENT_BYTE               = 1,
     ALIGNMENT_FLOAT16_IEEE       = 2,

--- a/pya2l/extensions/asam_types.hpp
+++ b/pya2l/extensions/asam_types.hpp
@@ -5,7 +5,7 @@
 
 using toke_type = std::size_t;
 
-enum class PredefinedType : std::uint16_t {
+enum class PredefinedType : uint16_t {
     Int        = 1,
     Uint       = 2,
     Long       = 3,
@@ -128,13 +128,13 @@ struct IntegralType : public AsamType {
     const bool              is_signed = std::is_signed_v<Ty>;
 };
 
-struct Int : IntegralType<std::int16_t> {};
+struct Int : IntegralType<int16_t> {};
 
-struct UInt : public IntegralType<std::uint16_t> {};
+struct UInt : public IntegralType<uint16_t> {};
 
-struct Long : public IntegralType<std::int32_t> {};
+struct Long : public IntegralType<int32_t> {};
 
-struct ULong : public IntegralType<std::uint32_t> {};
+struct ULong : public IntegralType<uint32_t> {};
 
 struct Float : public AsamType {
     Float() {
@@ -147,7 +147,7 @@ struct Float : public AsamType {
         // return (value < m_limits.min() || value > m_limits.max()) ? false : true;
     }
 
-    long double tofloat(std::string_view text_value, std::uint8_t radix = 10) const {
+    long double tofloat(std::string_view text_value, uint8_t radix = 10) const {
         return std::strtold(text_value.data(), nullptr);
     }
 

--- a/pya2l/extensions/gen_token_files.py
+++ b/pya2l/extensions/gen_token_files.py
@@ -410,7 +410,7 @@ with open("token_type.hpp", "wt") as of:
             item = f'"{item}"'
         of.write(f"""    {{{item}, {idx}}},\n""")
     of.write("};\n\n")
-    of.write("enum class TokenType: std::uint16_t {\n")
+    of.write("enum class TokenType: uint16_t {\n")
     for idx in range(275):
         of.write(f"\tT__{idx}={idx + 1},\n")
     for n, v in TPs:
@@ -420,7 +420,7 @@ with open("token_type.hpp", "wt") as of:
 
 with open("a2ltoken.hpp", "wt") as of:
     of.write(HEADER2)
-    of.write("enum class A2LTokenType: std::uint16_t {\n")
+    of.write("enum class A2LTokenType: uint16_t {\n")
 
     li = [(idx, item) for idx, item in enumerate(literalNames)]
     li.extend([(v, k) for k, v in TPs])

--- a/pya2l/extensions/ifdata.hpp
+++ b/pya2l/extensions/ifdata.hpp
@@ -95,8 +95,8 @@ class IfDataBuilder : public IfDataBase {
    private:
 
     void set_line_numbers() noexcept {
-        std::uint64_t start_line = 0;
-        std::uint64_t start_col  = 0;
+        uint64_t start_line = 0;
+        uint64_t start_col  = 0;
 
         for (auto tk : m_tokens) {
             if ((tk.m_token_class == TokenClass::REGULAR) && (tk.m_payload == "IF_DATA")) {

--- a/pya2l/extensions/keyword.hpp
+++ b/pya2l/extensions/keyword.hpp
@@ -8,7 +8,7 @@
 template<>
 struct std::hash<A2LTokenType> {
     std::size_t operator()(const A2LTokenType &s) const noexcept {
-        return std::hash<std::uint16_t>{}(static_cast<std::uint16_t>(s));
+        return std::hash<uint16_t>{}(static_cast<uint16_t>(s));
     }
 };
 

--- a/pya2l/extensions/line_map.hpp
+++ b/pya2l/extensions/line_map.hpp
@@ -52,7 +52,7 @@ class LineMap {
         if (item.has_value()) {
             auto idx                                             = item.value();
             auto& [abs_start, abs_end, rel_start, rel_end, name] = m_items[idx];
-            std::int64_t offset                                  = (abs_start - rel_start);
+            int64_t offset                                  = (abs_start - rel_start);
             return std::tuple<std::string, std::size_t>(name, line_no - offset);
         } else {
             return std::nullopt;
@@ -60,7 +60,7 @@ class LineMap {
     }
 
     void add_entry(
-        const std::string& path, std::uint64_t abs_start, std::uint64_t abs_end, std::uint64_t rel_start, std::uint64_t rel_end
+        const std::string& path, uint64_t abs_start, uint64_t abs_end, uint64_t rel_start, uint64_t rel_end
     ) {
         m_items.push_back(
             std::tuple<decltype(abs_start), decltype(abs_end), decltype(rel_start), decltype(rel_end), decltype(path)>{

--- a/pya2l/extensions/parameter.hpp
+++ b/pya2l/extensions/parameter.hpp
@@ -10,7 +10,7 @@
 class Parameter {
    public:
 
-    using type_t = enum class ParameterType : std::uint8_t {
+    using type_t = enum class ParameterType : uint8_t {
         INTEGRAL,
         ENUMERATION,
         TUPLE
@@ -94,7 +94,7 @@ bool validate(const Parameter& p, const ANTLRToken* token, const AsamVariantType
     bool ok{ false };
 
     if (std::size(p.get_enumerators()) == 0) {
-        const auto entry = ASAM_TYPES[std::bit_cast<std::uint16_t>(p.m_type) - 1];
+        const auto entry = ASAM_TYPES[std::bit_cast<uint16_t>(p.m_type) - 1];
         ok              = entry->validate(value);
 		if (!ok) {
             spdlog::get("a2lparser")->warn("Value out of range [{}:{}]", token->line(), token->column());
@@ -147,7 +147,7 @@ AsamVariantType convert(PredefinedType type, std::string_view text) {
 class ParameterTupleParser {
    public:
 
-    enum class StateType : std::uint8_t {
+    enum class StateType : uint8_t {
         IDLE = 0,
         COLLECTING,
         EXCESS_TOKENS,
@@ -194,7 +194,7 @@ class ParameterTupleParser {
                 m_tuple_size = std::size(m_parameter.get_tuple_elements());
                 m_row.resize(m_tuple_size);
                 m_state = StateType::COLLECTING;
-                m_token_count = std::numeric_limits<std::uint64_t>::max();
+                m_token_count = std::numeric_limits<uint64_t>::max();
             }
             auto type       = std::get<0>(m_tuple_elements[m_column]);
             m_row[m_column] = convert(type, token->getText());

--- a/pya2l/extensions/preprocessor.hpp
+++ b/pya2l/extensions/preprocessor.hpp
@@ -124,7 +124,7 @@ class Preprocessor {
     }
 
     void _process_file(const std::string& filename) {
-        std::uint64_t      start_line_number = 1;
+        uint64_t      start_line_number = 1;
         fs::path           path{ filename };
         auto               abs_pth = fs::absolute(path);
         std::ifstream      file(abs_pth, std::ios::binary);
@@ -134,7 +134,7 @@ class Preprocessor {
         bool               ifdata_name = false;
         bool               collect{ false };
         bool               include     = false;
-        std::uint8_t       skip_tokens = 0;
+        uint8_t       skip_tokens = 0;
         std::vector<Token> collected_tokens{};
         bool               suppress_comments{ true };
 
@@ -326,7 +326,7 @@ class Preprocessor {
     }
 
     void update_line_map(
-        const fs::path& path, std::uint64_t abs_start, std::uint64_t abs_end, std::uint64_t rel_start, std::uint64_t rel_end
+        const fs::path& path, uint64_t abs_start, uint64_t abs_end, uint64_t rel_start, uint64_t rel_end
     ) {
         const auto key = shorten_file_name(path);
         line_map.add_entry(path.string(), abs_start, abs_end, rel_start, rel_end);

--- a/pya2l/extensions/spdlog/fmt/bundled/chrono.h
+++ b/pya2l/extensions/spdlog/fmt/bundled/chrono.h
@@ -1097,7 +1097,7 @@ inline auto to_nonnegative_int(T value, Int upper) -> Int {
   return int_value;
 }
 
-constexpr auto pow10(std::uint32_t n) -> long long {
+constexpr auto pow10(uint32_t n) -> long long {
   return n == 0 ? 1 : 10 * pow10(n - 1);
 }
 

--- a/pya2l/extensions/spdlog/sinks/wincolor_sink-inl.h
+++ b/pya2l/extensions/spdlog/sinks/wincolor_sink-inl.h
@@ -42,7 +42,7 @@ SPDLOG_INLINE wincolor_sink<ConsoleMutex>::~wincolor_sink() {
 // change the color for the given level
 template <typename ConsoleMutex>
 void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_color(level::level_enum level,
-                                                          std::uint16_t color) {
+                                                          uint16_t color) {
     std::lock_guard<mutex_t> lock(mutex_);
     colors_[static_cast<size_t>(level)] = color;
 }
@@ -112,8 +112,8 @@ void SPDLOG_INLINE wincolor_sink<ConsoleMutex>::set_color_mode_impl(color_mode m
 
 // set foreground color and return the orig console attributes (for resetting later)
 template <typename ConsoleMutex>
-std::uint16_t SPDLOG_INLINE
-wincolor_sink<ConsoleMutex>::set_foreground_color_(std::uint16_t attribs) {
+uint16_t SPDLOG_INLINE
+wincolor_sink<ConsoleMutex>::set_foreground_color_(uint16_t attribs) {
     CONSOLE_SCREEN_BUFFER_INFO orig_buffer_info;
     if (!::GetConsoleScreenBufferInfo(static_cast<HANDLE>(out_handle_), &orig_buffer_info)) {
         // just return white if failed getting console info
@@ -125,7 +125,7 @@ wincolor_sink<ConsoleMutex>::set_foreground_color_(std::uint16_t attribs) {
     auto ignored =
         ::SetConsoleTextAttribute(static_cast<HANDLE>(out_handle_), static_cast<WORD>(new_attribs));
     (void)(ignored);
-    return static_cast<std::uint16_t>(orig_buffer_info.wAttributes);  // return orig attribs
+    return static_cast<uint16_t>(orig_buffer_info.wAttributes);  // return orig attribs
 }
 
 // print a range of formatted message to console

--- a/pya2l/extensions/spdlog/sinks/wincolor_sink.h
+++ b/pya2l/extensions/spdlog/sinks/wincolor_sink.h
@@ -30,7 +30,7 @@ public:
     wincolor_sink &operator=(const wincolor_sink &other) = delete;
 
     // change the color for the given level
-    void set_color(level::level_enum level, std::uint16_t color);
+    void set_color(level::level_enum level, uint16_t color);
     void log(const details::log_msg &msg) final override;
     void flush() final override;
     void set_pattern(const std::string &pattern) override final;
@@ -43,10 +43,10 @@ protected:
     mutex_t &mutex_;
     bool should_do_colors_;
     std::unique_ptr<spdlog::formatter> formatter_;
-    std::array<std::uint16_t, level::n_levels> colors_;
+    std::array<uint16_t, level::n_levels> colors_;
 
     // set foreground color and return the orig console attributes (for resetting later)
-    std::uint16_t set_foreground_color_(std::uint16_t attribs);
+    uint16_t set_foreground_color_(uint16_t attribs);
 
     // print a range of formatted message to console
     void print_range_(const memory_buf_t &formatted, size_t start, size_t end);

--- a/pya2l/extensions/sysconsts.hpp
+++ b/pya2l/extensions/sysconsts.hpp
@@ -11,7 +11,7 @@
 #include "ctre.hpp"
 
 
-using sys_const_variant_t = std::variant<std::monostate, std::int64_t, long double, std::string>;
+using sys_const_variant_t = std::variant<std::monostate, int64_t, long double, std::string>;
 using sys_const_t = std::map<std::string, sys_const_variant_t>;
 
 

--- a/pya2l/extensions/token_stream.hpp
+++ b/pya2l/extensions/token_stream.hpp
@@ -18,11 +18,14 @@
         #pragma warning(disable: 4251 4273)
     #endif
 
- #ifdef _WIN64
+ #if defined(_WIN64)
 typedef __int64 ssize_t;
-    #else
+#elif defined(_WIN32) && !defined(_SSIZE_T_DEFINED)
 typedef __int32 ssize_t;
-    #endif
+#define _SSIZE_T_DEFINED
+#else
+#include <unistd.h>  // On POSIX systems, ssize_t is already defined here
+#endif
 
 template<typename Ty_>
 class FixedSizeStack {
@@ -162,7 +165,7 @@ class ANTLRToken /*: public antlr4::Token*/ {
                std::to_string(m_start_line) + ":" + std::to_string(m_start_column - 1) + "]";
     }
 
-    std::int16_t channel() const {
+    int16_t channel() const {
         return DEFAULT_CHANNEL;
     }
 
@@ -273,19 +276,19 @@ class TokenReader {
         }
     }
 
-    ANTLRToken *LT(std::int64_t i) {
+    ANTLRToken *LT(int64_t i) {
         if (i == -1) {
             return &m_lastToken;
         }
 
         sync(i);
 
-        std::int64_t index = static_cast<std::int64_t>(_p) + i - 1;
+        int64_t index = static_cast<int64_t>(_p) + i - 1;
         if (index < 0) {
             throw IndexOutOfBoundsException(std::string("LT(") + std::to_string(i) + std::string(") gives negative index"));
         }
 
-        if (index >= static_cast<std::int64_t>(_tokens.size())) {
+        if (index >= static_cast<int64_t>(_tokens.size())) {
             // assert(_tokens.size() > 0 && _tokens.back()->type()) == ANTLRToken::EOF);
             return &_tokens.back();
         }
@@ -293,7 +296,7 @@ class TokenReader {
         return &_tokens[static_cast<std::size_t>(index)];
     }
 
-    ANTLRToken::token_t LA(std::int64_t k) noexcept {
+    ANTLRToken::token_t LA(int64_t k) noexcept {
         return LT(k)->type();
     }
 

--- a/pya2l/extensions/token_stream.hpp
+++ b/pya2l/extensions/token_stream.hpp
@@ -18,7 +18,7 @@
         #pragma warning(disable: 4251 4273)
     #endif
 
- #if defined(_WIN64)
+#if defined(_WIN64)
 typedef __int64 ssize_t;
 #elif defined(_WIN32) && !defined(_SSIZE_T_DEFINED)
 typedef __int32 ssize_t;

--- a/pya2l/extensions/token_type.hpp
+++ b/pya2l/extensions/token_type.hpp
@@ -292,7 +292,7 @@ const std::map<std::string, int, std::less<>> A2L_KEYWORDS{
 	{ "NOT_IN_ECU",					  290 },
 };
 
-enum class TokenType : std::uint16_t {
+enum class TokenType : uint16_t {
     T__0    = 1,
     T__1    = 2,
     T__2    = 3,
@@ -582,6 +582,6 @@ enum class TokenType : std::uint16_t {
 	T_290	= 290,
 };
 
-constexpr std::uint16_t DATA_TYPE_MIN = static_cast<std::uint16_t>(TokenType::IDENT);
+constexpr uint16_t DATA_TYPE_MIN = static_cast<uint16_t>(TokenType::IDENT);
 
 #endif  // __TOKEN_TYPE_HPP

--- a/pya2l/extensions/tokenizer.cpp
+++ b/pya2l/extensions/tokenizer.cpp
@@ -40,7 +40,7 @@ std::vector<Token> split_by_new_line(std::string_view line, std::size_t start_li
 
     char const        *cstr     = line.data();
     char const * const START    = line.data();
-    const std::int64_t LAST_IDX = line.length() - 1;
+    const int64_t LAST_IDX = line.length() - 1;
 
     if (LAST_IDX < 1) {
         return std::vector<Token>{
@@ -53,8 +53,8 @@ std::vector<Token> split_by_new_line(std::string_view line, std::size_t start_li
         };
     }
 
-    std::int64_t       pos  = 0;
-    std::int64_t       prev = -1;
+    int64_t       pos  = 0;
+    int64_t       prev = -1;
     auto               row  = start_line;
     LineNumbers        line_numbers{};
     std::vector<Token> result;
@@ -164,7 +164,7 @@ Generator<TokenizerReturnType> tokenizer(std::basic_istream<char> &stream, bool 
     };
 
     constexpr auto char_class_to_int = [](const CharClass &cc) noexcept {
-        return static_cast<std::int8_t>(cc);
+        return static_cast<int8_t>(cc);
     };
 
     const auto in_comment = [&comment_state]() noexcept {

--- a/pya2l/extensions/tokenizer.hpp
+++ b/pya2l/extensions/tokenizer.hpp
@@ -33,7 +33,7 @@
     #include "token_type.hpp"
     #include "utils.hpp"
 
-enum class CharClass : std::int8_t {
+enum class CharClass : int8_t {
     NONE       = -1,
     WHITESPACE = 0,
     REGULAR    = 1,
@@ -47,13 +47,13 @@ constexpr char NL      = '\n';
 constexpr char CR      = '\r';
 constexpr char DQUOTE  = '"';
 
-enum class StringStateType : std::uint8_t {
+enum class StringStateType : uint8_t {
     IDLE,
     IN_STRING,
     MAY_CLOSE,
 };
 
-enum class CommentStateType : std::uint8_t {
+enum class CommentStateType : uint8_t {
     IDLE,
     MAY_START,
     SINGLE_LINE,
@@ -61,7 +61,7 @@ enum class CommentStateType : std::uint8_t {
     MAY_CLOSE
 };
 
-enum class TokenClass : std::uint8_t {
+enum class TokenClass : uint8_t {
     REGULAR,
     WHITESPACE,
     COMMENT,
@@ -91,7 +91,7 @@ struct Token {
     Token(Token &&)                 = default;
 
     TokenClass    m_token_class;
-    std::uint16_t m_token_type{ std::bit_cast<std::uint16_t>(INVALID) };
+    uint16_t m_token_type{ std::bit_cast<uint16_t>(INVALID) };
     LineNumbers   m_line_numbers;
     std::string   m_payload;
 
@@ -104,27 +104,27 @@ struct Token {
 
     void set_token_type() {
         if (m_token_class == TokenClass::WHITESPACE) {
-            m_token_type = static_cast<std::uint16_t>(WS);
+            m_token_type = static_cast<uint16_t>(WS);
         } else if (m_token_class == TokenClass::COMMENT) {
-            m_token_type = static_cast<std::uint16_t>(COMMENT);
+            m_token_type = static_cast<uint16_t>(COMMENT);
         } else if (m_token_class == TokenClass::STRING) {
-            m_token_type = static_cast<std::uint16_t>(STRING);
+            m_token_type = static_cast<uint16_t>(STRING);
             trim(m_payload);
         } else {
             const auto entry = A2L_KEYWORDS.find(m_payload);
 
             if (entry != A2L_KEYWORDS.end()) {
-                m_token_type = static_cast<std::uint16_t>(entry->second);
+                m_token_type = static_cast<uint16_t>(entry->second);
             } else {
                 if (ctre::match<PAT_INT>(m_payload)) {
-                    m_token_type = static_cast<std::uint16_t>(INT);
+                    m_token_type = static_cast<uint16_t>(INT);
                 } else if (ctre::match<PAT_HEX>(m_payload)) {
-                    m_token_type = static_cast<std::uint16_t>(HEX);
+                    m_token_type = static_cast<uint16_t>(HEX);
                 } else if (ctre::match<PAT_FLOAT>(m_payload)) {
-                    m_token_type = static_cast<std::uint16_t>(FLOAT);
+                    m_token_type = static_cast<uint16_t>(FLOAT);
                 } else {
                     // std::cout << "\tIDEN�T: " << m_payload << std::endl;
-                    m_token_type = static_cast<std::uint16_t>(IDENT);
+                    m_token_type = static_cast<uint16_t>(IDENT);
                 }
             }
         }

--- a/pya2l/extensions/utils.hpp
+++ b/pya2l/extensions/utils.hpp
@@ -33,7 +33,7 @@
 
     #define PP_UNREFERENCED_PARAMETER(p) ((p) = (p))
 
-enum class State : std::uint8_t {
+enum class State : uint8_t {
     IDLE,
     IN_STRING,
 };
@@ -92,7 +92,7 @@ static inline void rstrip(std::string &s) noexcept {
 /*
  * Cut out section of text and replace it with a single space.
  */
-inline void blank_out(std::string &text, std::int32_t start, std::int32_t end) noexcept {
+inline void blank_out(std::string &text, int32_t start, int32_t end) noexcept {
     if (end == -1) {
         text.resize(start);
     } else {


### PR DESCRIPTION
adding posix import where ssize_t is already defined and removing some std::int* std::uint* from errors while building to address #76 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the **CONTRIBUTING** document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

wheel built successfully
```sh
(venv) (18:47:28) slondono@slondono-Inspiron-7373 ~/src/repos/slondono_fork/pyA2L (ampz9-fix-linux-build)
$ pip install -e .
Obtaining file:///home/slondono/src/repos/slondono_fork/pyA2L
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Collecting numpy<3,>=1.26.4
  Using cached numpy-2.2.6-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (16.8 MB)
Collecting SQLAlchemy<3.0.0,>=2.0.30
  Using cached sqlalchemy-2.0.41-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.2 MB)
Collecting rich<14.0.0,>=13.7.1
  Using cached rich-13.9.4-py3-none-any.whl (242 kB)
Collecting scipy<2.0.0,>=1.15.0
  Using cached scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (37.7 MB)
Collecting Mako<2.0.0,>=1.3.5
  Using cached mako-1.3.10-py3-none-any.whl (78 kB)
Collecting chardet<6.0.0,>=5.2.0
  Using cached chardet-5.2.0-py3-none-any.whl (199 kB)
Collecting MarkupSafe>=0.9.2
  Using cached MarkupSafe-3.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (20 kB)
Collecting pygments<3.0.0,>=2.13.0
  Using cached pygments-2.19.1-py3-none-any.whl (1.2 MB)
Collecting typing-extensions<5.0,>=4.0.0
  Using cached typing_extensions-4.14.0-py3-none-any.whl (43 kB)
Collecting markdown-it-py>=2.2.0
  Using cached markdown_it_py-3.0.0-py3-none-any.whl (87 kB)
Collecting greenlet>=1
  Using cached greenlet-3.2.3-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl (582 kB)
Collecting mdurl~=0.1
  Using cached mdurl-0.1.2-py3-none-any.whl (10.0 kB)
Building wheels for collected packages: pya2ldb
  Building editable for pya2ldb (pyproject.toml) ... done
  Created wheel for pya2ldb: filename=pya2ldb-0.15.4-cp310-cp310-manylinux_2_35_x86_64.whl size=9592 sha256=31ebb590a698f639bfe950f0688ed20ac8b77f134640740c328c15dabf10e79a
  Stored in directory: /tmp/pip-ephem-wheel-cache-ljwj0_5u/wheels/32/a8/c2/ce47bcda00a3a175b5c7d0fddb83b14b51d91c176db8bdef6e
Successfully built pya2ldb
Installing collected packages: typing-extensions, pygments, numpy, mdurl, MarkupSafe, greenlet, chardet, SQLAlchemy, scipy, markdown-it-py, Mako, rich, pya2ldb
Successfully installed Mako-1.3.10 MarkupSafe-3.0.2 SQLAlchemy-2.0.41 chardet-5.2.0 greenlet-3.2.3 markdown-it-py-3.0.0 mdurl-0.1.2 numpy-2.2.6 pya2ldb-0.15.4 pygments-2.19.1 rich-13.9.4 scipy-1.15.3 typing-extensions-4.14.0
```
test:
```sh
$ python ampz9_test.py 
[2025-06-17 16:43:57.672] [preprocessor] [info] Preprocessing and tokenizing '/home/slondono/src/repos/pyA2L/examples/ASAP2_Demo_V161.a2l'.
[2025-06-17 16:43:57.679] [a2l] [info] Elapsed Time: 0.006[s]
[2025-06-17 16:43:57.679] [a2l] [info] Start parsing...
[2025-06-17 16:43:57.681] [a2l] [info] Elapsed Time: 0.002[s]
[2025-06-17 16:43:57.681] [a2l] [info] Number of keywords: 444
  writing to DB... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% Elapsed: 0:00:00 Remaining: 0:00:00
ASAM.M.ARRAY_SIZE_16.UBYTE.IDENTICAL             UBYTE        0x00013a30
ASAM.M.MATRIX_DIM_16_1_1.UBYTE.IDENTICAL         UBYTE        0x00013a30
ASAM.M.MATRIX_DIM_8_2_1.UBYTE.IDENTICAL          UBYTE        0x00013a30
ASAM.M.MATRIX_DIM_8_4_2.UBYTE.IDENTICAL          UBYTE        0x00013a30
ASAM.M.SCALAR.FLOAT32.IDENTICAL                  FLOAT32_IEEE 0x00013a10
ASAM.M.SCALAR.FLOAT64.IDENTICAL                  FLOAT64_IEEE 0x00013a14
ASAM.M.SCALAR.SBYTE.IDENTICAL                    SBYTE        0x00013a01
ASAM.M.SCALAR.SBYTE.LINEAR_MUL_2                 SBYTE        0x00013a01
ASAM.M.SCALAR.SLONG.IDENTICAL                    SLONG        0x00013a0c
ASAM.M.SCALAR.SWORD.IDENTICAL                    SWORD        0x00013a04
ASAM.M.SCALAR.UBYTE.FORM_X_PLUS_4                UBYTE        0x00013a00
ASAM.M.SCALAR.UBYTE.IDENTICAL                    UBYTE        0x00013a00
ASAM.M.SCALAR.UBYTE.TAB_INTP_DEFAULT_VALUE       UBYTE        0x00013a00
ASAM.M.SCALAR.UBYTE.TAB_INTP_NO_DEFAULT_VALUE    UBYTE        0x00013a00
ASAM.M.SCALAR.UBYTE.TAB_NOINTP_DEFAULT_VALUE     UBYTE        0x00013a00
ASAM.M.SCALAR.UBYTE.TAB_NOINTP_NO_DEFAULT_VALUE  UBYTE        0x00013a00
ASAM.M.SCALAR.UBYTE.TAB_VERB_DEFAULT_VALUE       UBYTE        0x00013a00
ASAM.M.SCALAR.UBYTE.TAB_VERB_NO_DEFAULT_VALUE    UBYTE        0x00013a00
ASAM.M.SCALAR.UBYTE.VTAB_RANGE_DEFAULT_VALUE     UBYTE        0x00013a00
ASAM.M.SCALAR.UBYTE.VTAB_RANGE_NO_DEFAULT_VALUE  UBYTE        0x00013a00
ASAM.M.SCALAR.ULONG.IDENTICAL                    ULONG        0x00013a08
ASAM.M.SCALAR.UWORD.IDENTICAL                    UWORD        0x00013a02
ASAM.M.SCALAR.UWORD.IDENTICAL.BITMASK_0008       UWORD        0x00013a20
ASAM.M.SCALAR.UWORD.IDENTICAL.BITMASK_0FF0       UWORD        0x00013a20
ASAM.M.VIRTUAL.SCALAR.SWORD.PHYSICAL             SWORD        0x00000000
```